### PR TITLE
Fixed port address/universe

### DIFF
--- a/lib/artnet_server.js
+++ b/lib/artnet_server.js
@@ -26,7 +26,7 @@ exports.listen = function(port, cb) {
 		// Deseralize the data - magic numbers are as per the Art-Net protocol
 		var sequence = data[12];
 		var physical = data[13];
-		var universe = (data[14] * 256) + data[15];
+		var port_address = (data[15] << 8) + data[14];
 		var length = (data[16] * 256) + data[17];
 		
 		var rawData = new Array();
@@ -35,7 +35,11 @@ exports.listen = function(port, cb) {
 		}
 			
 		// Build the associative array to return
-		var retData = {sequence: sequence, physical: physical, universe: universe, length: length, data: rawData};
+		var retData = {sequence: sequence,
+		               physical: physical,
+		               port_address: port_address,
+		               length: length,
+		               data: rawData};
 		
 		// And call the callback passing the deseralized data
 		cb(retData, peer);


### PR DESCRIPTION
`universe` is the incorrect term here because the `universe` is the bottom four bits of the port address. Also, the `subnet/universe` byte goes below the `net` 7-bits. I've also corrected this.

Also, any plans to combine this library and the other [ArtNet Node lib](https://www.npmjs.org/package/artnet)?
