### PR TITLE
fix for Node v8 (Object.setPrototypeOf called on null or undefined)

### DIFF
--- a/lib/artnet_server.js
+++ b/lib/artnet_server.js
@@ -1,36 +1,48 @@
 var util = require('util');
-var EventEmitter = require('events');
+var events = require('events');
 var dgram = require('dgram');
 
 // ArtNet server class
-function listen(port, cb) {
-	this.port = port;
-	EventEmitter.call(this);
-	
-	// Set up the socket
-	var sock = dgram.createSocket("udp4", function (msg, peer) {
-		
-		var sequence = msg.readUInt8(12,true);	
-		var physical = msg.readUInt8(13,true);
-		var universe = msg.readUInt8(14,true);
-		var offset = msg.readUInt8(16,true);
-		var length = msg.readUInt8(17,true);
-		
-		var rawData = [];
-	
-		for( i = 18; i < 18 + length; i++ ){
-			rawData.push( msg.readUInt8(i) );
-		}
-		
-		var retData = {sequence: sequence, physical: physical, universe: universe, length: length, data: rawData};
-		
-		// And call the callback passing the deseralized data
-		cb(retData, peer);
-	});
-	sock.bind(port);
+module.exports = class ArtnetServer extends events.EventEmitter {
+    constructor (port, cb) {
+        super();
+        this.port = port;
+        call(this);
+
+        // Set up the socket
+        var sock = dgram.createSocket("udp4", function (msg, peer) {
+            var data = new Array();
+            for (i = 0; i < msg.length; i++) {
+                var d = msg.toString().charCodeAt(i);
+                // Since we can't do unsigned 8-bit integers, do some normalization
+                if (d < 0) {
+                    d = 0;
+                } else if (d > 255) {
+                    d = 255;
+                }
+                
+                // Append the byte to the array
+                data.push(d);
+            }
+            
+            // Deseralize the data - magic numbers are as per the Art-Net protocol
+            var sequence = data[12];
+            var physical = data[13];
+            var universe = (data[14] * 256) + data[15];
+            var length = (data[16] * 256) + data[17];
+            
+            var rawData = new Array();
+            for (i = 0; i < length; i++) {
+                rawData.push(data[i + 18]);
+            }
+                
+            // Build the associative array to return
+            var retData = {sequence: sequence, physical: physical, universe: universe, length: length, data: rawData};
+            
+            // And call the callback passing the deseralized data
+            cb(retData, peer);
+        });
+        sock.bind(port);
+          
+    }
 }
-
-// Setup EventEmitter for the ArtNetServer
-util.inherits(listen, EventEmitter);
-
-exports.listen = listen


### PR DESCRIPTION
I am a user of Node-RED
I was using the output node "node-red-artnet-node" relying on this
"artnet-node" package and it came to prevent my Node-RED from starting after upgrading to Node-RED v0.17.5 and Node.js v8.9.1 because  of  ``TypeError: Object.setPrototypeOf called on null or undefined``

To fix it, I refactored the server stuff following the advices found at:
https://stackoverflow.com/questions/39099527/typeerror-object-setprototypeof-called-on-null-or-undefined

I'm not a expert of javascript nor of Node.js and couldn't try my new
version with Artnet hardware.
I think it should work again but PLEASE READ CAREFULLY MY PR BEFORE MERGING !
At least, my server doesnt crash anymore at startup nor when trying to send Artnet stuffs from Node-RED :D